### PR TITLE
Updated Slider Slick Arrow be visible in dark mode

### DIFF
--- a/src/sections/Home/So-Special-Section/so-special-style.js
+++ b/src/sections/Home/So-Special-Section/so-special-style.js
@@ -41,7 +41,6 @@ const SoSpecialWrapper = styled.div`
         font-size: 6rem;
         display: inline-block;
         height: 3rem;
-        filter: invert(${(props) => props.theme.meshInterfaceLogoFilter});
     }
     .slick-arrow:hover:before{	
         color: ${props => props.theme.secondaryColor};


### PR DESCRIPTION
I have removed
`filter: invert(${(props) => props.theme.meshInterfaceLogoFilter});`

from `.slick-arrow:before` class so the arrows will be visible in dark mode

Signed-off-by: Yahaya Muhammad Bello <mbyahya2579@gmail.com>

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
